### PR TITLE
Changed '_.any' to '_.some' and fixed 'isAnimating' naming conflict

### DIFF
--- a/AnimationCollections.framer/modules/AnimationSet.coffee
+++ b/AnimationCollections.framer/modules/AnimationSet.coffee
@@ -1,51 +1,51 @@
 # Animation Set
 # Manages a set of Animations
-# 
+#
 # by Isaac Weinhausen
 # http://isaacw.com
 
 
 class exports.AnimationSet extends Framer.EventEmitter
-	
+
 	constructor: (options = {}) ->
 		@_animationsArray = []
 		@add(animation) for k, animation of options.animations
 		@repeat = options.repeat ? false
-			
+
 	add: (animation) =>
-		
+
 		# Ensure the animation is stopped (needed when passed via the layer.animate method)
 		animation.stop()
-		
+
 		# Have the animation track its animating state
-		animation.isAnimating = false
-		
+		animation.isAnimatingCheck = false
+
 		animation.on Events.AnimationEnd, =>
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 			@_update()
-			
+
 		@_animationsArray.push animation
-	
-	
+
+
 	_update: () =>
 		# Have all animations stopped?
-		if not @isAnimating()
+		if not @isAnimatingCheck()
 			if @repeat
 				@start()
 			else
 				@emit Events.AnimationEnd
-		
-	isAnimating: =>
-		_.any(@_animationsArray, "isAnimating", true)
-	
+
+	isAnimatingCheck: =>
+		_.some(@_animationsArray, "isAnimatingCheck", true)
+
 	start: =>
 		for animation in @_animationsArray
 			animation.start()
-			animation.isAnimating = true
+			animation.isAnimatingCheck = true
 		@emit Events.AnimationStart
-		
+
 	stop: =>
 		for animation in @_animationsArray
 			animation.stop()
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 		@emit Events.AnimationStop

--- a/examples/basic-sequence.framer/modules/AnimationSet.coffee
+++ b/examples/basic-sequence.framer/modules/AnimationSet.coffee
@@ -1,51 +1,51 @@
 # Animation Set
 # Manages a set of Animations
-# 
+#
 # by Isaac Weinhausen
 # http://isaacw.com
 
 
 class exports.AnimationSet extends Framer.EventEmitter
-	
+
 	constructor: (options = {}) ->
 		@_animationsArray = []
 		@add(animation) for k, animation of options.animations
 		@repeat = options.repeat ? false
-			
+
 	add: (animation) =>
-		
+
 		# Ensure the animation is stopped (needed when passed via the layer.animate method)
 		animation.stop()
-		
+
 		# Have the animation track its animating state
-		animation.isAnimating = false
-		
+		animation.isAnimatingCheck = false
+
 		animation.on Events.AnimationEnd, =>
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 			@_update()
-			
+
 		@_animationsArray.push animation
-	
-	
+
+
 	_update: () =>
 		# Have all animations stopped?
-		if not @isAnimating()
+		if not @isAnimatingCheck()
 			if @repeat
 				@start()
 			else
 				@emit Events.AnimationEnd
-		
-	isAnimating: =>
-		_.any(@_animationsArray, "isAnimating", true)
-	
+
+	isAnimatingCheck: =>
+		_.some(@_animationsArray, "isAnimatingCheck", true)
+
 	start: =>
 		for animation in @_animationsArray
 			animation.start()
-			animation.isAnimating = true
+			animation.isAnimatingCheck = true
 		@emit Events.AnimationStart
-		
+
 	stop: =>
 		for animation in @_animationsArray
 			animation.stop()
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 		@emit Events.AnimationStop

--- a/examples/basic-set.framer/modules/AnimationSet.coffee
+++ b/examples/basic-set.framer/modules/AnimationSet.coffee
@@ -1,51 +1,51 @@
 # Animation Set
 # Manages a set of Animations
-# 
+#
 # by Isaac Weinhausen
 # http://isaacw.com
 
 
 class exports.AnimationSet extends Framer.EventEmitter
-	
+
 	constructor: (options = {}) ->
 		@_animationsArray = []
 		@add(animation) for k, animation of options.animations
 		@repeat = options.repeat ? false
-			
+
 	add: (animation) =>
-		
+
 		# Ensure the animation is stopped (needed when passed via the layer.animate method)
 		animation.stop()
-		
+
 		# Have the animation track its animating state
-		animation.isAnimating = false
-		
+		animation.isAnimatingCheck = false
+
 		animation.on Events.AnimationEnd, =>
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 			@_update()
-			
+
 		@_animationsArray.push animation
-	
-	
+
+
 	_update: () =>
 		# Have all animations stopped?
-		if not @isAnimating()
+		if not @isAnimatingCheck()
 			if @repeat
 				@start()
 			else
 				@emit Events.AnimationEnd
-		
-	isAnimating: =>
-		_.any(@_animationsArray, "isAnimating", true)
-	
+
+	isAnimatingCheck: =>
+		_.some(@_animationsArray, "isAnimatingCheck", true)
+
 	start: =>
 		for animation in @_animationsArray
 			animation.start()
-			animation.isAnimating = true
+			animation.isAnimatingCheck = true
 		@emit Events.AnimationStart
-		
+
 	stop: =>
 		for animation in @_animationsArray
 			animation.stop()
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 		@emit Events.AnimationStop

--- a/examples/dynamic-sequence.framer/modules/AnimationSet.coffee
+++ b/examples/dynamic-sequence.framer/modules/AnimationSet.coffee
@@ -1,51 +1,51 @@
 # Animation Set
 # Manages a set of Animations
-# 
+#
 # by Isaac Weinhausen
 # http://isaacw.com
 
 
 class exports.AnimationSet extends Framer.EventEmitter
-	
+
 	constructor: (options = {}) ->
 		@_animationsArray = []
 		@add(animation) for k, animation of options.animations
 		@repeat = options.repeat ? false
-			
+
 	add: (animation) =>
-		
+
 		# Ensure the animation is stopped (needed when passed via the layer.animate method)
 		animation.stop()
-		
+
 		# Have the animation track its animating state
-		animation.isAnimating = false
-		
+		animation.isAnimatingCheck = false
+
 		animation.on Events.AnimationEnd, =>
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 			@_update()
-			
+
 		@_animationsArray.push animation
-	
-	
+
+
 	_update: () =>
 		# Have all animations stopped?
-		if not @isAnimating()
+		if not @isAnimatingCheck()
 			if @repeat
 				@start()
 			else
 				@emit Events.AnimationEnd
-		
-	isAnimating: =>
-		_.any(@_animationsArray, "isAnimating", true)
-	
+
+	isAnimatingCheck: =>
+		_.some(@_animationsArray, "isAnimatingCheck", true)
+
 	start: =>
 		for animation in @_animationsArray
 			animation.start()
-			animation.isAnimating = true
+			animation.isAnimatingCheck = true
 		@emit Events.AnimationStart
-		
+
 	stop: =>
 		for animation in @_animationsArray
 			animation.stop()
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 		@emit Events.AnimationStop

--- a/examples/mixed-collections.framer/modules/AnimationSet.coffee
+++ b/examples/mixed-collections.framer/modules/AnimationSet.coffee
@@ -1,51 +1,51 @@
 # Animation Set
 # Manages a set of Animations
-# 
+#
 # by Isaac Weinhausen
 # http://isaacw.com
 
 
 class exports.AnimationSet extends Framer.EventEmitter
-	
+
 	constructor: (options = {}) ->
 		@_animationsArray = []
 		@add(animation) for k, animation of options.animations
 		@repeat = options.repeat ? false
-			
+
 	add: (animation) =>
-		
+
 		# Ensure the animation is stopped (needed when passed via the layer.animate method)
 		animation.stop()
-		
+
 		# Have the animation track its animating state
-		animation.isAnimating = false
-		
+		animation.isAnimatingCheck = false
+
 		animation.on Events.AnimationEnd, =>
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 			@_update()
-			
+
 		@_animationsArray.push animation
-	
-	
+
+
 	_update: () =>
 		# Have all animations stopped?
-		if not @isAnimating()
+		if not @isAnimatingCheck()
 			if @repeat
 				@start()
 			else
 				@emit Events.AnimationEnd
-		
-	isAnimating: =>
-		_.any(@_animationsArray, "isAnimating", true)
-	
+
+	isAnimatingCheck: =>
+		_.some(@_animationsArray, "isAnimatingCheck", true)
+
 	start: =>
 		for animation in @_animationsArray
 			animation.start()
-			animation.isAnimating = true
+			animation.isAnimatingCheck = true
 		@emit Events.AnimationStart
-		
+
 	stop: =>
 		for animation in @_animationsArray
 			animation.stop()
-			animation.isAnimating = false
+			animation.isAnimatingCheck = false
 		@emit Events.AnimationStop


### PR DESCRIPTION
Resolves #3 and makes the `AnimationSet` module usable again in the most recent version of Framer (v112).